### PR TITLE
Prepare release v0.3.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # fiction-template (development version)
 
+# fiction-template (0.3.0)
+
+* Project initialisation script (init.sh) added.
+* texlive-science and texlive-latex-extra packages removed from the install Make target.
+* README updated with project initialisation documentation.
+
 # fiction-template (0.2.0)
 
 * Dependency installation (make install).

--- a/init.sh
+++ b/init.sh
@@ -25,5 +25,5 @@ rm NEWS.md
 git init
 git switch --create main
 git add --all -- :!init.sh
-git commit -m "Initial commit based on fiction-template v0.2.0."
+git commit -m "Initial commit based on fiction-template v0.3.0."
 rm init.sh


### PR DESCRIPTION
The only change since the previous release are the addition of an initialisation script, removal of texlive-science and texlive-latex-extra packages from the installation Make target and updated documentation in the README.